### PR TITLE
fix: add auto_increment for database primary keys

### DIFF
--- a/src/db/migration-0-apply.sql
+++ b/src/db/migration-0-apply.sql
@@ -1,10 +1,3 @@
-drop table if exists `article_tag`;
-drop table if exists `tag`;
-drop table if exists `comment`;
-drop table if exists `article`;
-drop table if exists `user_follower`;
-drop table if exists `user`;
-
 create table `user` (
     user_id integer not null,
     username varchar(50) not null,

--- a/src/db/migration-0-rollback.sql
+++ b/src/db/migration-0-rollback.sql
@@ -1,0 +1,6 @@
+drop table if exists `article_tag`;
+drop table if exists `tag`;
+drop table if exists `comment`;
+drop table if exists `article`;
+drop table if exists `follower`;
+drop table if exists `user`;

--- a/src/db/migration-1-apply.sql
+++ b/src/db/migration-1-apply.sql
@@ -1,0 +1,13 @@
+-- user_id auto increment
+
+alter table `follower` drop foreign key `follower_fk_user`;
+alter table `follower` drop foreign key `follower_fk_follower`;
+alter table `article` drop foreign key `article_fk_author`;
+alter table `comment` drop foreign key `comment_fk_commenter`;
+
+alter table `user` modify column `user_id` int not null auto_increment;
+
+alter table `follower` add constraint `follower_fk_user` foreign key (user_id) references `user` (user_id);
+alter table `follower` add constraint `follower_fk_follower` foreign key  (follower_id) references `user` (user_id);
+alter table `article` add constraint `article_fk_author` foreign key  (author_id) references `user` (user_id);
+alter table `comment` add constraint `comment_fk_commenter` foreign key (commenter_id) references `user` (user_id);

--- a/src/db/migration-1-rollback.sql
+++ b/src/db/migration-1-rollback.sql
@@ -1,0 +1,11 @@
+alter table `follower` drop foreign key `follower_fk_user`;
+alter table `follower` drop foreign key `follower_fk_follower`;
+alter table `article` drop foreign key `article_fk_author`;
+alter table `comment` drop foreign key `comment_fk_commenter`;
+
+alter table `user` modify column `user_id` int not null;
+
+alter table `follower` add constraint `follower_fk_user` foreign key (user_id) references `user` (user_id);
+alter table `follower` add constraint `follower_fk_follower` foreign key  (follower_id) references `user` (user_id);
+alter table `article` add constraint `article_fk_author` foreign key  (author_id) references `user` (user_id);
+alter table `comment` add constraint `comment_fk_commenter` foreign key (commenter_id) references `user` (user_id);

--- a/src/db/migration-2-apply.sql
+++ b/src/db/migration-2-apply.sql
@@ -1,0 +1,3 @@
+-- comment auto_increment
+
+alter table `comment` modify column `comment_id` int not null auto_increment;

--- a/src/db/migration-2-rollback.sql
+++ b/src/db/migration-2-rollback.sql
@@ -1,0 +1,1 @@
+alter table `comment` modify column `comment_id` int not null;

--- a/src/db/migration-3-apply.sql
+++ b/src/db/migration-3-apply.sql
@@ -1,0 +1,5 @@
+-- tag auto_increment
+
+alter table article_tag drop foreign key article_tag_fk_tag;
+alter table tag modify column tag_id int not null auto_increment;
+alter table article_tag add constraint article_tag_fk_tag foreign key (tag_id) references tag(tag_id);

--- a/src/db/migration-3-rollback.sql
+++ b/src/db/migration-3-rollback.sql
@@ -1,0 +1,3 @@
+alter table article_tag drop foreign key article_tag_fk_tag;
+alter table tag modify column tag_id int not null;
+alter table article_tag add constraint article_tag_fk_tag foreign key (tag_id) references tag(tag_id);

--- a/src/db/migration-4-apply.sql
+++ b/src/db/migration-4-apply.sql
@@ -1,0 +1,6 @@
+-- article auto_increment
+alter table article_tag drop foreign key article_tag_fk_article;
+alter table `comment` drop foreign key `comment_fk_article`;
+alter table article modify column article_id int not null auto_increment;
+alter table `comment` add constraint `comment_fk_article` foreign key (article_id) references article(article_id);
+alter table article_tag add constraint article_tag_fk_article foreign key (article_id) references article(article_id);

--- a/src/db/migration-4-rollback.sql
+++ b/src/db/migration-4-rollback.sql
@@ -1,0 +1,5 @@
+alter table article_tag drop foreign key article_tag_fk_article;
+alter table `comment` drop foreign key `comment_fk_article`;
+alter table article modify column article_id int not null;
+alter table `comment` add constraint `comment_fk_article` foreign key (article_id) references article(article_id);
+alter table article_tag add constraint article_tag_fk_article foreign key (article_id) references article(article_id);

--- a/src/db/schema.sql
+++ b/src/db/schema.sql
@@ -31,7 +31,7 @@ DROP TABLE IF EXISTS `article`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `article` (
-  `article_id` int NOT NULL,
+  `article_id` int NOT NULL AUTO_INCREMENT,
   `author_id` int NOT NULL,
   `title` varchar(100) NOT NULL,
   `slug` varchar(100) NOT NULL,
@@ -147,4 +147,4 @@ CREATE TABLE `user` (
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2024-12-02 11:36:58
+-- Dump completed on 2024-12-02 11:45:07

--- a/src/db/schema.sql
+++ b/src/db/schema.sql
@@ -1,0 +1,150 @@
+-- MySQL dump 10.13  Distrib 8.0.40, for macos14.4 (x86_64)
+--
+-- Host: 127.0.0.1    Database: temp
+-- ------------------------------------------------------
+-- Server version	8.0.40-0ubuntu0.24.10.1
+
+/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
+/*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
+/*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
+/*!50503 SET NAMES utf8mb4 */;
+/*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
+/*!40103 SET TIME_ZONE='+00:00' */;
+/*!40014 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0 */;
+/*!40014 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0 */;
+/*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */;
+/*!40111 SET @OLD_SQL_NOTES=@@SQL_NOTES, SQL_NOTES=0 */;
+
+--
+-- Current Database: `temp`
+--
+
+CREATE DATABASE /*!32312 IF NOT EXISTS*/ `temp` /*!40100 DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci */ /*!80016 DEFAULT ENCRYPTION='N' */;
+
+USE `temp`;
+
+--
+-- Table structure for table `article`
+--
+
+DROP TABLE IF EXISTS `article`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `article` (
+  `article_id` int NOT NULL,
+  `author_id` int NOT NULL,
+  `title` varchar(100) NOT NULL,
+  `slug` varchar(100) NOT NULL,
+  `description` varchar(1000) NOT NULL,
+  `body` text NOT NULL,
+  `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `deleted_at` timestamp NULL DEFAULT NULL,
+  PRIMARY KEY (`article_id`),
+  KEY `article_fk_author` (`author_id`),
+  CONSTRAINT `article_fk_author` FOREIGN KEY (`author_id`) REFERENCES `user` (`user_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `article_tag`
+--
+
+DROP TABLE IF EXISTS `article_tag`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `article_tag` (
+  `article_id` int NOT NULL,
+  `tag_id` int NOT NULL,
+  PRIMARY KEY (`article_id`,`tag_id`),
+  KEY `article_tag_fk_tag` (`tag_id`),
+  CONSTRAINT `article_tag_fk_article` FOREIGN KEY (`article_id`) REFERENCES `article` (`article_id`),
+  CONSTRAINT `article_tag_fk_tag` FOREIGN KEY (`tag_id`) REFERENCES `tag` (`tag_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `comment`
+--
+
+DROP TABLE IF EXISTS `comment`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `comment` (
+  `comment_id` int NOT NULL AUTO_INCREMENT,
+  `article_id` int NOT NULL,
+  `commenter_id` int NOT NULL,
+  `body` varchar(100) NOT NULL,
+  `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `deleted_at` timestamp NULL DEFAULT NULL,
+  PRIMARY KEY (`comment_id`),
+  KEY `comment_fk_article` (`article_id`),
+  KEY `comment_fk_commenter` (`commenter_id`),
+  CONSTRAINT `comment_fk_article` FOREIGN KEY (`article_id`) REFERENCES `article` (`article_id`),
+  CONSTRAINT `comment_fk_commenter` FOREIGN KEY (`commenter_id`) REFERENCES `user` (`user_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `follower`
+--
+
+DROP TABLE IF EXISTS `follower`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `follower` (
+  `user_id` int NOT NULL,
+  `follower_id` int NOT NULL,
+  `followed_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (`user_id`,`follower_id`),
+  KEY `follower_fk_follower` (`follower_id`),
+  CONSTRAINT `follower_fk_follower` FOREIGN KEY (`follower_id`) REFERENCES `user` (`user_id`),
+  CONSTRAINT `follower_fk_user` FOREIGN KEY (`user_id`) REFERENCES `user` (`user_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `tag`
+--
+
+DROP TABLE IF EXISTS `tag`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `tag` (
+  `tag_id` int NOT NULL AUTO_INCREMENT,
+  `name` varchar(100) NOT NULL,
+  PRIMARY KEY (`tag_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `user`
+--
+
+DROP TABLE IF EXISTS `user`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `user` (
+  `user_id` int NOT NULL AUTO_INCREMENT,
+  `username` varchar(50) NOT NULL,
+  `email` varchar(200) NOT NULL,
+  `password_hash` varchar(200) NOT NULL,
+  `bio` text NOT NULL,
+  `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `deleted_at` timestamp NULL DEFAULT NULL,
+  PRIMARY KEY (`user_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
+
+/*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
+/*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */;
+/*!40014 SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS */;
+/*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
+/*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
+/*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
+/*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
+
+-- Dump completed on 2024-12-02 11:36:58


### PR DESCRIPTION
resolves #11 

데이터베이스 DDL 작성시 sqlite를 활용하여 DDL을 작성한 후, mysql로 옮기는 과정에서 SQL 방언의 차이로 인해 pk에 대해서 auto\_increment가 선언되지 않았다. 관련 테이블의 pk들을 migration함으로써 해결하였다.

- **fix: migrate user table**
- **fix: migrate comment table**
- **fix: migrate tag table**
- **feat: dump database schema**
- **fix: migrate article table**
